### PR TITLE
Fixed issue loading vtranman from tranman

### DIFF
--- a/src/main/abl/adetran/pm/_pmmain.p
+++ b/src/main/abl/adetran/pm/_pmmain.p
@@ -1092,7 +1092,7 @@ ON CHOOSE OF BtnVT IN FRAME MainFrame DO:
   ELSE DO:
     RUN adecomm/_setcurs.p ("WAIT":U).
     /* RUN adetran/pm/_reports.w. */
-    RUN _RunTool( INPUT "_vtran.p").
+    RUN _RunTool( INPUT "wrappers/_vtran.p").
     RUN ResetMain.
   END.
 END.


### PR DESCRIPTION
When accessing Visual Translation Manager icon available in 'Translation Manager' window, it fails with an error message stating "_vtran.p not found". Fixed this issue as part of the PR.